### PR TITLE
Don't update labels onEnabledStateChanged

### DIFF
--- a/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -157,7 +157,7 @@ public class CheckboxGroup<T>
         } else {
             setDisabled(!enabled);
         }
-        refreshCheckboxes();
+        getCheckboxItems().forEach(this::updateEnabled);
     }
 
     @Override

--- a/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -30,7 +30,9 @@ import org.junit.Test;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.selection.MultiSelectionEvent;
 
@@ -260,6 +262,20 @@ public class CheckboxGroupTest {
         Set<String> newSelection = eventCapture.get().getNewSelection();
         Assert.assertTrue(newSelection.contains("foo"));
         Assert.assertTrue(newSelection.contains("bar"));
+    }
+
+    @Test // https://github.com/vaadin/vaadin-checkbox-flow/issues/81
+    public void disableParent_detachParent_notThrowing() {
+        CheckboxGroup<String> checkboxGroup = new CheckboxGroup<>();
+        checkboxGroup.setItems("foo", "bar");
+
+        Div parent = new Div(checkboxGroup);
+
+        UI ui = new UI();
+        ui.add(parent);
+
+        parent.setEnabled(false);
+        ui.remove(parent);
     }
 
     private CheckboxGroup<Wrapper> getRefreshEventCheckboxGroup(


### PR DESCRIPTION
Fix #81

Updating the text content of disabled checkbox when detaching the
CheckBoxGroup throws an exception. Only the disabled-state needs to be
updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox-flow/102)
<!-- Reviewable:end -->
