### PR TITLE
Clarify that CheckboxGroup.setValue(null) throws

### DIFF
--- a/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
+++ b/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/CheckboxGroup.java
@@ -128,6 +128,27 @@ public class CheckboxGroup<T>
         setValue(value);
     }
 
+    /**
+     * Sets the value of this component. If the new value is not equal to the
+     * previous value, fires a value change event.
+     * <p>
+     * The component doesn't accept {@code null} values. The value of a checkbox
+     * group without any selected items is an empty set. You can use the
+     * {@link #clear()} method to set the empty value.
+     * 
+     * @param value
+     *            the new value to set, not {@code null}
+     * @throws NullPointerException
+     *             if value is {@code null}
+     */
+    @Override
+    public void setValue(Set<T> value) {
+        Objects.requireNonNull(value,
+                "Cannot set a null value to checkbox group. "
+                        + "Use the clear-method to reset the component's value to an empty set.");
+        super.setValue(value);
+    }
+
     @Override
     public Set<T> getSelectedItems() {
         return getValue();

--- a/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
+++ b/vaadin-checkbox-flow/src/test/java/com/vaadin/flow/component/checkbox/tests/CheckboxGroupTest.java
@@ -25,7 +25,9 @@ import java.util.stream.Collectors;
 
 import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
@@ -40,6 +42,23 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 
 public class CheckboxGroupTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void hasEmptySetAsDefaultValue() {
+        Set<Object> value = new CheckboxGroup<>().getValue();
+        Assert.assertNotNull(value);
+        Assert.assertTrue(value.isEmpty());
+    }
+
+    @Test
+    public void setValueNull_throws() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("Use the clear-method");
+        new CheckboxGroup<>().setValue(null);
+    }
 
     @Test
     public void setReadOnlyCheckboxGroup_groupIsReadOnlyAndDisabled() {


### PR DESCRIPTION
It was not clear to me whether a null value can be set to clear the
selection. This change adds a more meaningful error message, improves
JavaDocs and adds a couple of test cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-checkbox-flow/113)
<!-- Reviewable:end -->
