### PR TITLE
fix: bump missing checkbox version

### DIFF
--- a/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
+++ b/vaadin-checkbox-flow/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckboxGroup.java
@@ -124,7 +124,7 @@ import com.vaadin.flow.shared.Registration;
         "WebComponent: Vaadin.CheckboxGroupElement#2.2.2",
         "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-checkbox-group")
-@NpmPackage(value = "@vaadin/vaadin-checkbox", version = "2.2.13")
+@NpmPackage(value = "@vaadin/vaadin-checkbox", version = "2.3.0")
 @JsModule("@vaadin/vaadin-checkbox/src/vaadin-checkbox-group.js")
 @HtmlImport("frontend://bower_components/vaadin-checkbox/src/vaadin-checkbox-group.html")
 public abstract class GeneratedVaadinCheckboxGroup<R extends GeneratedVaadinCheckboxGroup<R, T>, T>


### PR DESCRIPTION
This cause error of two different versions being used.